### PR TITLE
Add Android builds to support Termux compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
+        goos: [linux, windows, darwin, android]
         goarch: [amd64, arm64, arm, 386]
         exclude:
           - goos: darwin

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,13 @@ case "$ARCH" in
 esac
 
 BINARY="BPB-Warp-Scanner"
-ARCHIVE="${BINARY}-linux-${ARCH}.tar.gz"
+OS=$(uname -o)
+
+if [[ "$OS" == *Android* ]]; then
+    ARCHIVE="${BINARY}-android-${ARCH}.tar.gz"
+else 
+    ARCHIVE="${BINARY}-linux-${ARCH}.tar.gz"
+fi
 
 if [ -x "./${BINARY}" ]; then
     INSTALLED_VERSION=$("./${BINARY}" --version)


### PR DESCRIPTION
While working on this PR, I realized that `Linux/arm*` binaries are **not compatible with Android devices**. So I added a few lines to properly detect and handle Android environments (e.g., Termux).

However, there's a problem: your custom Xray repository ([`bia-pain-bache/Xray-Core`](https://github.com/bia-pain-bache/Xray-Core)) does **not currently provide binaries for Android**, so the code will **still not work correctly on Android** even after this PR is merged.

In fact, running a standard Linux ARM64 binary on Termux results in the following error:

```
error: ".../BPB-Warp-Scanner-linux-arm64/BPB-Warp-Scanner" has unexpected e_type: 2
```

This indicates that the binary is not in the expected **Android-compatible format (e.g., PIE ELF)**, which reinforces the need for a proper Android build.

Since I’m not familiar with how **XTLS builds its core**, and the `.yml` files in your repo are a bit complex, I’m kindly asking you to **set up a proper Android build target** in your CI workflow.

That would make the tool fully functional across both standard Linux and Android platforms.